### PR TITLE
balena-image: add linux-firmware-iwlwifi to generic-amd64

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
@@ -22,3 +22,7 @@ BALENA_BOOT_PARTITION_FILES_append_generic-amd64 = " \
     "
 # Increase image rootfs size to accomodate more drivers and functionality in generic images
 IMAGE_ROOTFS_SIZE = "1048576"
+
+IMAGE_INSTALL_append_generic-amd64 = " \
+    linux-firmware-iwlwifi \
+    "


### PR DESCRIPTION
This adds firmware for Intel wireless chipsets supported by the iwlwifi
driver. Tested with AX200 chipset.

Changelog-entry: balena-image: add linux-firmware-iwlwifi to generic-amd64
Signed-off-by: Joseph Kogut <joseph@balena.io>