### PR TITLE
balena-image: use the same IMAGE_ROOTFS_MAXSIZE as genericx86-64-ext

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
@@ -21,7 +21,8 @@ BALENA_BOOT_PARTITION_FILES_append_generic-amd64 = " \
     grub/x86_64-efi/:/EFI/BOOT/x86_64-efi/ \
     "
 # Increase image rootfs size to accomodate more drivers and functionality in generic images
-IMAGE_ROOTFS_SIZE = "1048576"
+# This matches the value in the balena-intel genericx86-64-ext DT for compatibility
+IMAGE_ROOTFS_SIZE = "1024000"
 
 IMAGE_INSTALL_append_generic-amd64 = " \
     linux-firmware \


### PR DESCRIPTION
Use the same image size as genericx86-64-ext for compatiblity. This
allows the generic-amd64 image to replace genericx86-64-ext when they
reach feature parity, without causing hostapp-update problems later.

Signed-off-by: Joseph Kogut <joseph@balena.io>