### PR TITLE
genericx86-64-ext: Deploy both flasher and non-flasher artifacts

### DIFF
--- a/genericx86-64-ext.coffee
+++ b/genericx86-64-ext.coffee
@@ -46,7 +46,8 @@ module.exports =
 		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
+		deployArtifact: 'balena-image-genericx86-64-ext.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-genericx86-64-ext.balenaos-img'
 		compressed: true
 
 	configuration:


### PR DESCRIPTION
This allows leviathan tests to avoid having to unwrap flasher images.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>