### PR TITLE
Add contracts submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git
+[submodule "contracts"]
+	path = contracts
+	url = https://github.com/balena-io/contracts.git

--- a/repo.yml
+++ b/repo.yml
@@ -6,3 +6,5 @@ upstream:
     url: 'http://github.com/balena-os/meta-balena'
   - repo: 'balena-yocto-scripts'
     url: 'http://github.com/balena-os/balena-yocto-scripts'
+  - repo: 'contracts'
+    url: 'https://github.com/balena-io/contracts.git'


### PR DESCRIPTION
This is used to build and deploy an OS contract to the fleet.

Changelog-entry: Add contracts submodule
Signed-off-by: Alex Gonzalez <alexg@balena.io>
