### PR TITLE
hostapp-update-hooks: Install grub update hooks

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.inc
@@ -27,4 +27,5 @@ IMAGE_ROOTFS_SIZE = "1024000"
 
 IMAGE_INSTALL_append = " \
     linux-firmware \
+    efibootmgr \
     "

--- a/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+#
+# Script which cleans up boot partition of redundant files
+#
+
+set -o errexit
+
+. /usr/sbin/balena-config-vars
+
+DURING_UPDATE=${DURING_UPDATE:-0}
+
+if [ "$DURING_UPDATE" = "1" ]; then
+	grub_cfg=$(find "$BALENA_BOOT_MOUNTPOINT" -name grub.cfg)
+	if  grep -q "search --set=root" "$grub_cfg" ; then
+		if [ -e "$BALENA_BOOT_MOUNTPOINT/vmlinuz" ]; then
+			# Testing the destination sysroot bzImage is tricky. Lets check current root
+			# instead as all future roots will have the kernel in root partition in /boot
+			# This leaves the kernel lying around in boot partition until the next HUP
+			if [ -e "/boot/bzImage" ]; then
+				printf "[INFO] grub.cfg reads kernel from root partitions but found vmlinuz in boot \n"
+				printf "[INFO] removing $BALENA_BOOT_MOUNTPOINT/vmlinuz \n"
+				rm -f "$BALENA_BOOT_MOUNTPOINT/vmlinuz" || true
+				sync -f "$BALENA_BOOT_MOUNTPOINT"
+			fi
+		fi
+	fi
+
+	# make sure the bootstrap code (boot.img) is removed in case we are using EFI boot
+	if [ -d /sys/firmware/efi ] ; then
+		device="/dev/"$(findmnt --noheadings --canonicalize --output SOURCE "$BALENA_BOOT_MOUNTPOINT" | xargs lsblk -no pkname)
+		dd if=/dev/zero of=$device bs=446 count=1
+
+		# re-add the EFI entry for resinOS boot from internal media as some EFI firmwares are buggy and won't detect the old entry anymore
+		# first remove existing resinOS entries so we won't have duplicates
+		printf "[INFO] Re-add EFI boot entry for starting resinOS from internal media.\n"
+		mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+		duplicates=`efibootmgr | grep resinOS |sed 's/Boot*//g' | sed 's/* resinOS//g'`
+		for i in $duplicates; do efibootmgr -B -b $i; done
+		efibootmgr -c -d $device -p 1 -L "resinOS" -l "\EFI\BOOT\bootx64.efi"
+	fi
+fi

--- a/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
+++ b/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/hostapp-update-hooks.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+HOSTAPP_HOOKS += " \
+  99-resin-grub \
+  999-resin-boot-cleaner \
+  "
+
+RDEPENDS_${PN} += "util-linux-lsblk"


### PR DESCRIPTION
The grub hook is required to set change the boot
partition after a HUP.

The boot-cleaner hook is copied from balena-intel
to clean the boot partition of redundant files.

Changelog-entry: hostapp-update-hooks: Install grub update hooks
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-os/balena-generic/issues/115