### PR TITLE
bblayers: Modify layer ordering

### DIFF
--- a/layers/meta-balena-generic/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-generic/conf/samples/bblayers.conf.sample
@@ -6,14 +6,14 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-rust \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-common \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-dunfell \
+    ${TOPDIR}/../layers/meta-balena-generic \
     ${TOPDIR}/../layers/poky/meta \
     ${TOPDIR}/../layers/poky/meta-poky \
     ${TOPDIR}/../layers/meta-openembedded/meta-oe \
     ${TOPDIR}/../layers/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
-    ${TOPDIR}/../layers/meta-rust \
-    ${TOPDIR}/../layers/meta-balena/meta-balena-common \
-    ${TOPDIR}/../layers/meta-balena/meta-balena-dunfell \
-    ${TOPDIR}/../layers/meta-balena-generic \
     "


### PR DESCRIPTION
Yocto classes and conf files ignore layer priorities and are parsed
in order instead.

Changelog-entry: Modify layer ordering
Signed-off-by: Alex Gonzalez <alexg@balena.io>
