### PR TITLE
meta-balena-generic: add uname26 personality patch

### DIFF
--- a/layers/meta-balena-generic/recipes-kernel/linux/files/generic-aarch64/0001-UBUNTU-SAUCE-no-up-add-compat_uts_machine-kernel-com.patch
+++ b/layers/meta-balena-generic/recipes-kernel/linux/files/generic-aarch64/0001-UBUNTU-SAUCE-no-up-add-compat_uts_machine-kernel-com.patch
@@ -1,0 +1,42 @@
+From: Andy Whitcroft <apw@canonical.com>
+Date: Fri, 27 Nov 2015 17:38:30 +0000
+Subject: [PATCH] UBUNTU: SAUCE: (no-up) add compat_uts_machine= kernel command
+ line override
+
+We wish to use the arm64 buildds to build armhf binaries in 32bit chroots.
+To make this work we need uname to return armv7l machine type.  To achieve
+this add a kernel command line override for the 32bit machine type.
+Add compat_uts_machine=<type> to allow the LINUX32 personality to return
+that type for uname.
+
+Signed-off-by: Andy Whitcroft <apw@canonical.com>
+---
+ kernel/sys.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/kernel/sys.c b/kernel/sys.c
+index 83ffd7dccf23..5b030fbaf199 100644
+--- a/kernel/sys.c
++++ b/kernel/sys.c
+@@ -1138,6 +1138,21 @@ SYSCALL_DEFINE0(setsid)
+ 
+ DECLARE_RWSEM(uts_sem);
+ 
++#ifdef COMPAT_UTS_MACHINE
++static char compat_uts_machine[__OLD_UTS_LEN+1] = COMPAT_UTS_MACHINE;
++
++static int __init parse_compat_uts_machine(char *arg)
++{
++	strncpy(compat_uts_machine, arg, __OLD_UTS_LEN);
++	compat_uts_machine[__OLD_UTS_LEN] = 0;
++	return 0;
++}
++early_param("compat_uts_machine", parse_compat_uts_machine);
++
++#undef COMPAT_UTS_MACHINE
++#define COMPAT_UTS_MACHINE compat_uts_machine
++#endif
++
+ #ifdef COMPAT_UTS_MACHINE
+ #define override_architecture(name) \
+ 	(personality(current->personality) == PER_LINUX32 && \

--- a/layers/meta-balena-generic/recipes-kernel/linux/files/generic-aarch64/0002-HACK-Use-the-UNAME26-personality-to-return-armv6l-in.patch
+++ b/layers/meta-balena-generic/recipes-kernel/linux/files/generic-aarch64/0002-HACK-Use-the-UNAME26-personality-to-return-armv6l-in.patch
@@ -1,0 +1,73 @@
+From: Zubair Lutfullah Kakakhel <zubair@balena.io>
+Date: Mon, 11 Feb 2019 15:52:06 +0000
+Subject: [PATCH] HACK: Use the UNAME26 personality to return armv6l instead of
+ v2.6.32+
+
+We'd like to make our arm builders return two different machine strings
+at runtime for different processes. armv7l and armv6l. This is so that
+a docker daemon for armv6l/armv8l device builds thinks the docker build
+is unning under the correct machine arch. Various package managers such
+as pip rely on the output of uname -m to be correct.
+
+The UNAME26 personality is used by old userspace programs to make the
+kernel version string appear as 2.6+.
+
+Add a hack in the kernel to modify the machine string for the uname26
+personality and make it show armv6l. And don't change the kernel
+version string to 2.6.+
+
+The benefit of this hack instead of adding a new personality is
+- we won't have to carry a custom version of the setarch userspace utility
+- simpler to implement and keep lying around
+
+Trade-off. I'm hoping no customer is pushing applications that depend
+on the kernel version string being 2.6+ and the actual uname26
+personality usage.
+
+With this patch and compat_uts_machine=armv7l in the kernel cmdline
+on our arm builder
+
+root@arm02:~# linux32 --uname-2.6 uname -m
+armv6l
+root@arm02:~# linux32 uname -m
+armv7l
+root@arm02:~# uname -m
+aarch64
+root@arm02:~#
+
+Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>
+---
+ kernel/sys.c | 19 ++-----------------
+ 1 file changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/kernel/sys.c b/kernel/sys.c
+index 4e0a24b0c14d..f8807b47740b 100644
+--- a/kernel/sys.c
++++ b/kernel/sys.c
+@@ -1173,24 +1173,9 @@ static int override_release(char __user *release, size_t len)
+ {
+ 	int ret = 0;
+ 
++	strncpy(compat_uts_machine, "armv7l", __OLD_UTS_LEN);
+ 	if (current->personality & UNAME26) {
+-		const char *rest = UTS_RELEASE;
+-		char buf[65] = { 0 };
+-		int ndots = 0;
+-		unsigned v;
+-		size_t copy;
+-
+-		while (*rest) {
+-			if (*rest == '.' && ++ndots >= 3)
+-				break;
+-			if (!isdigit(*rest) && *rest != '.')
+-				break;
+-			rest++;
+-		}
+-		v = ((LINUX_VERSION_CODE >> 8) & 0xff) + 60;
+-		copy = clamp_t(size_t, len, 1, sizeof(buf));
+-		copy = scnprintf(buf, copy, "2.6.%u%s", v, rest);
+-		ret = copy_to_user(release, buf, copy + 1);
++		strncpy(compat_uts_machine, "armv6l", __OLD_UTS_LEN);
+ 	}
+ 	return ret;
+ }

--- a/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -8,6 +8,8 @@ SRC_URI_append_generic-amd64 = " \
 
 SRC_URI_append_generic-aarch64 = " \
     file://defconfig;sha256sum=bcf0b7ae134386c459bc7bccce567792a553fe7735f28ea576746b5d656086cc \
+    file://0001-UBUNTU-SAUCE-no-up-add-compat_uts_machine-kernel-com.patch;sha256sum=38a9f1a5e896bfcc9e527d119a440d888d59b5d9881a9a08e3e91494790a5c26 \
+    file://0002-HACK-Use-the-UNAME26-personality-to-return-armv6l-in.patch;sha256sum=a3665233eebd44dc8f34ddda9ae9446bb1ef2f9c06979850bd9cc60d1e7d6f79 \
     "
 
 KCONFIG_MODE="--alldefconfig"


### PR DESCRIPTION
This allows to use this kernel in our ARM builder that require armv7l and armv6l machine strings to build.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>