### PR TITLE
generic-amd64: make flasher image default artifact

### DIFF
--- a/generic-amd64.coffee
+++ b/generic-amd64.coffee
@@ -46,7 +46,7 @@ module.exports =
 		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-generic-amd64.balenaos-img'
+		deployArtifact: 'balena-image-flasher-generic-amd64.balenaos-img'
 		deployFlasherArtifact: 'balena-image-flasher-generic-amd64.balenaos-img'
 		deployRawArtifact: 'balena-image-generic-amd64.balenaos-img'
 		compressed: true


### PR DESCRIPTION
We already process and upload both flasher and raw images that are explicitly labeled, but for legacy reasons, the unlabeled image is also used as the default. Upload the flasher image as the default/unlabeled artifact to remain consistent with the genericx86-64-ext DT provided in balena-intel.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>