### PR TITLE
balena-image: include peak driver

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.bbappend
@@ -1,1 +1,3 @@
 include balena-image.inc
+
+IMAGE_INSTALL:append = " peak"


### PR DESCRIPTION
This is a 3rd party CAN driver, we want to include it in the generic device types.