### PR TITLE
generic-aarch64: add modules for usb booting to initramfs

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,1 +1,7 @@
 IMAGE_ROOTFS_MAXSIZE = "65536"
+
+PACKAGE_INSTALL:append:generic-aarch64 = " \
+    kernel-module-sd-mod \
+    kernel-module-uas \
+    kernel-module-xhci-pci \
+"


### PR DESCRIPTION
Changelog-entry: Add modules required to boot from USB to initramfs
Signed-off-by: Joseph Kogut <joseph@balena.io>