### PR TITLE
machine: define serial consoles for both amd64 and aarch64

### DIFF
--- a/layers/meta-balena-generic/conf/machine/generic-aarch64.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-aarch64.conf
@@ -11,5 +11,7 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 
 KERNEL_IMAGETYPE = "Image.gz"
 
+SERIAL_CONSOLES = "115200;ttyS0"
+
 DEFAULTTUNE ?= "aarch64"
 SERIAL_CONSOLES = "115200;ttyAMA0"

--- a/layers/meta-balena-generic/conf/machine/generic-amd64.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-amd64.conf
@@ -10,6 +10,8 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 
 KERNEL_IMAGETYPE ?= "bzImage"
 
+SERIAL_CONSOLES ?= "115200;ttyS0"
+
 DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/x86/tune-core2.inc
 


### PR DESCRIPTION
This is used in OS development mode to enable serial consoles.

Changelog-entry: Define serial consoles for amd64 and aarch64
Signed-off-by: Alex Gonzalez <alexg@balena.io>