### PR TITLE
flasher: add virtio device pattern

### DIFF
--- a/layers/meta-balena-generic/recipes-support/resin-init/resin-init-flasher.bbappend
+++ b/layers/meta-balena-generic/recipes-support/resin-init/resin-init-flasher.bbappend
@@ -1,3 +1,3 @@
-INTERNAL_DEVICE_KERNEL = "md/balena{,_*} nvme?n? sd? mmcblk?"
+INTERNAL_DEVICE_KERNEL = "md/balena{,_*} nvme?n? sd? mmcblk? vd?"
 INTERNAL_DEVICE_BOOTLOADER_CONFIG = "grub.cfg_internal"
 INTERNAL_DEVICE_BOOTLOADER_CONFIG_PATH = "/EFI/BOOT/grub.cfg"


### PR DESCRIPTION
Changelog-entry: Add virtio devices as installation target for flasher images
Signed-off-by: Joseph Kogut <joseph@balena.io>