### PR TITLE
bblayers: add meta-perl from OE

### DIFF
--- a/layers/meta-balena-generic/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-generic/conf/samples/bblayers.conf.sample
@@ -16,4 +16,5 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
+    ${TOPDIR}/../layers/meta-openembedded/meta-perl \
     "


### PR DESCRIPTION
Perl is required to build efitools, used for EFI boot entry configuration and secure boot.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>