### PR TITLE
generic-amd64: Add x86-64 machine override

### DIFF
--- a/layers/meta-balena-generic/conf/machine/generic-amd64.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-amd64.conf
@@ -15,3 +15,4 @@ SERIAL_CONSOLES ?= "115200;ttyS0"
 DEFAULTTUNE ?= "core2-64"
 require conf/machine/include/x86/tune-core2.inc
 
+MACHINEOVERRIDES = "x86-64:${MACHINE}"


### PR DESCRIPTION
This is used in other layers when architecture specific tweaks are needed.

Changelog-entry: Add x86-64 machine override to generic-amd64
Signed-off-by: Alex Gonzalez <alexg@balena.io>