### PR TITLE
machine: define raid machine feature

### DIFF
--- a/layers/meta-balena-generic/conf/machine/generic-aarch64.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-aarch64.conf
@@ -5,7 +5,7 @@
 require conf/machine/include/arm/arch-armv8a.inc
 require conf/machine/include/kernel.inc
 
-MACHINE_FEATURES += " efi"
+MACHINE_FEATURES += " efi raid"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 

--- a/layers/meta-balena-generic/conf/machine/generic-amd64.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-amd64.conf
@@ -4,7 +4,7 @@
 
 require conf/machine/include/kernel.inc
 
-MACHINE_FEATURES += " efi"
+MACHINE_FEATURES += " efi raid"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-modules linux-firmware"
 


### PR DESCRIPTION
Newer meta-balena uses the raid machine feature to include RAID support.

Changelog-entry: define raid in machine features for generic devices