### PR TITLE
Wait for grub-conf:do_deploy when copying files into boot partition

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.inc
@@ -29,3 +29,5 @@ IMAGE_INSTALL:append = " \
     linux-firmware \
     efibootmgr \
     "
+
+do_resin_boot_dirgen_and_deploy[depends] += "grub-conf:do_deploy"


### PR DESCRIPTION
There seems to be a race condition where `do_resin_boot_dirgen_and_deploy` is sometimes called before `grub-conf:do_deploy` which means the files are not ready yet and the build fails with

```
ERROR: balena-image-flasher-1.0-r0 do_resin_boot_dirgen_and_deploy: .../balena-generic/build/tmp/deploy/images/generic-amd64/grub.cfg_internal is an invalid path referenced in BALENA_BOOT_PARTITION_FILES.
```

This patch adds an explicit dependency that solves the issue.