### PR TITLE
hostapp-update-hooks: Don't fail if efivars fs already mounted

### DIFF
--- a/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -37,7 +37,10 @@ if [ "$DURING_UPDATE" = "1" ]; then
 			boot_part="/dev/$(lsblk -sJ "${boot_dev}" | jq -r '.blockdevices[].name')"
 			device="/dev/$(lsblk "$boot_part" -dnlo PKNAME)"
 			printf "[INFO] Re-add EFI boot entry for starting resinOS from internal media.\n"
-			mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+			if [ -z "$(ls -A /sys/firmware/efi/efivars)" ]; then
+				# efivars not bind-mounted by hostapp-update script
+				mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+			fi
 			duplicates=`efibootmgr | grep resinOS |sed 's/Boot*//g' | sed 's/* resinOS//g'`
 			for i in $duplicates; do efibootmgr -B -b $i; done
 			efibootmgr -c -d $device -p 1 -L "resinOS" -l "\EFI\BOOT\bootx64.efi"


### PR DESCRIPTION
This prevents the following error and hup abort when sysfs is bind-mounted in the hostapp-update container:
    mount: /sys/firmware/efi/efivars: efivarfs already mounted or mount point busy.

Changelog-entry: hostapp-update-hooks: Don't fail if efivars fs already mounted

Addresses one failure in https://github.com/balena-os/meta-balena/pull/3194