### PR TITLE
add generic-amd64-fs yocto-machine

### DIFF
--- a/generic-amd64-fs.coffee
+++ b/generic-amd64-fs.coffee
@@ -41,13 +41,13 @@ module.exports =
 		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
 
 	yocto:
-		machine: 'generic-amd64'
+		machine: 'generic-amd64-fs'
 		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'balena-image-flasher-generic-amd64.balenaos-img'
-		deployFlasherArtifact: 'balena-image-flasher-generic-amd64.balenaos-img'
-		deployRawArtifact: 'balena-image-generic-amd64.balenaos-img'
+		deployArtifact: 'balena-image-flasher-generic-amd64-fs.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-generic-amd64-fs.balenaos-img'
+		deployRawArtifact: 'balena-image-generic-amd64-fs.balenaos-img'
 		compressed: true
 
 	configuration:

--- a/layers/meta-balena-generic/conf/machine/generic-amd64-fs.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-amd64-fs.conf
@@ -1,0 +1,6 @@
+#@TYPE: Machine
+#@NAME: Generic amd64 fs
+#@DESCRIPTION: Machine configuration for Generic amd64 fs
+
+include conf/machine/generic-amd64.conf
+MACHINEOVERRIDES = "generic-amd64:${MACHINE}"

--- a/layers/meta-balena-generic/conf/samples/local.conf.sample
+++ b/layers/meta-balena-generic/conf/samples/local.conf.sample
@@ -1,6 +1,7 @@
 # Supported machines
 #MACHINE ?= "generic-aarch64.conf"
 #MACHINE ?= "generic-amd64.conf"
+#MACHINE ?= "generic-amd64-fs.conf"
 
 # More info meta-balena/README.md
 #RESIN_CONNECTABLE ?= "1"


### PR DESCRIPTION
This is to resolve build and deploy pipeline issues - perviously we were breaking our pipeline conventions which created a cascade of errors

Change-type: patch