### PR TITLE
kontron-come-xelx: Add new device type

### DIFF
--- a/kontron-come-xelx.coffee
+++ b/kontron-come-xelx.coffee
@@ -1,0 +1,61 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+DISABLE_SECURE_BOOT = 'Make sure Secure Boot is disabled in BIOS.'
+GENERIC_FLASH = '''
+	Please make sure you do not have any other USB keys inserted.
+	Power up the hardware. Make sure you have a keyboard connected.
+	Press the F10 key (may differ on some platforms) while BIOS is loading in order to enter the boot menu.
+	Next, select the name of your USB key.
+'''
+
+GENERIC_POWERON = 'Power on your device.'
+
+postProvisioningInstructions = [
+	instructions.BOARD_SHUTDOWN
+	instructions.REMOVE_INSTALL_MEDIA
+	GENERIC_POWERON
+]
+
+module.exports =
+	version: 1
+	slug: 'kontron-come-xelx'
+	name: 'Kontron COMe xELx'
+	arch: 'amd64'
+	state: 'new'
+
+	stateInstructions:
+		postProvisioning: postProvisioningInstructions
+
+	instructions: [
+		instructions.ETCHER_USB
+		instructions.EJECT_USB
+		instructions.FLASHER_WARNING
+		DISABLE_SECURE_BOOT
+		GENERIC_FLASH
+	].concat(postProvisioningInstructions)
+
+	gettingStartedLink:
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+
+	yocto:
+		machine: 'kontron-come-xelx'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
+		version: 'yocto-kirkstone'
+		deployArtifact: 'balena-image-flasher-kontron-come-xelx.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-kontron-come-xelx.balenaos-img'
+		deployRawArtifact: 'balena-image-kontron-come-xelx.balenaos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	options: [ networkOptions.group ]
+
+	initialization: commonImg.initialization

--- a/layers/meta-balena-generic/conf/machine/kontron-come-xelx.conf
+++ b/layers/meta-balena-generic/conf/machine/kontron-come-xelx.conf
@@ -1,0 +1,6 @@
+#@TYPE: Machine
+#@NAME: Kontron COMe xELx
+#@DESCRIPTION: Machine configuration for Kontron COMe xELx
+
+include conf/machine/generic-amd64.conf
+MACHINEOVERRIDES =. "generic-amd64:"

--- a/layers/meta-balena-generic/conf/samples/local.conf.sample
+++ b/layers/meta-balena-generic/conf/samples/local.conf.sample
@@ -2,6 +2,7 @@
 #MACHINE ?= "generic-aarch64.conf"
 #MACHINE ?= "generic-amd64.conf"
 #MACHINE ?= "generic-amd64-fs.conf"
+#MACHINE ?= "kontron-come-xelx"
 
 # More info meta-balena/README.md
 #RESIN_CONNECTABLE ?= "1"


### PR DESCRIPTION
This creates a new device type that uses kernel module signing.

This code is hosted temporarily in this repo. The machine should have its own device repo with the Kontron BSP. When that happens, this code from here must be removed.

Changelog-entry: Add new kontron-come-xelx device type for kernel module signing based on generic-amd64