### PR TITLE
studio-automatedx86-sb: Add new device type

### DIFF
--- a/layers/meta-balena-generic/conf/machine/studio-automatedx86-sb.conf
+++ b/layers/meta-balena-generic/conf/machine/studio-automatedx86-sb.conf
@@ -1,0 +1,6 @@
+#@TYPE: Machine
+#@NAME: Studio Automated X86 SB
+#@DESCRIPTION: Machine configuration for Studio Automated X86 SB
+
+include conf/machine/generic-amd64.conf
+MACHINEOVERRIDES =. "generic-amd64:"

--- a/layers/meta-balena-generic/conf/samples/local.conf.sample
+++ b/layers/meta-balena-generic/conf/samples/local.conf.sample
@@ -3,6 +3,7 @@
 #MACHINE ?= "generic-amd64.conf"
 #MACHINE ?= "generic-amd64-fs.conf"
 #MACHINE ?= "kontron-come-xelx"
+#MACHINE ?= "studio-automatedx86-sb"
 
 # More info meta-balena/README.md
 #RESIN_CONNECTABLE ?= "1"

--- a/studio-automatedx86-sb.coffee
+++ b/studio-automatedx86-sb.coffee
@@ -1,0 +1,61 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+DISABLE_SECURE_BOOT = 'Make sure Secure Boot is disabled in BIOS.'
+GENERIC_FLASH = '''
+	Please make sure you do not have any other USB keys inserted.
+	Power up the hardware. Make sure you have a keyboard connected.
+	Press the F10 key (may differ on some platforms) while BIOS is loading in order to enter the boot menu.
+	Next, select the name of your USB key.
+'''
+
+GENERIC_POWERON = 'Power on your device.'
+
+postProvisioningInstructions = [
+	instructions.BOARD_SHUTDOWN
+	instructions.REMOVE_INSTALL_MEDIA
+	GENERIC_POWERON
+]
+
+module.exports =
+	version: 1
+	slug: 'studio-automatedx86-sb'
+	name: 'Studio Automated X86 SB'
+	arch: 'amd64'
+	state: 'new'
+
+	stateInstructions:
+		postProvisioning: postProvisioningInstructions
+
+	instructions: [
+		instructions.ETCHER_USB
+		instructions.EJECT_USB
+		instructions.FLASHER_WARNING
+		DISABLE_SECURE_BOOT
+		GENERIC_FLASH
+	].concat(postProvisioningInstructions)
+
+	gettingStartedLink:
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+
+	yocto:
+		machine: 'studio-automatedx86-sb'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
+		version: 'yocto-kirkstone'
+		deployArtifact: 'balena-image-flasher-studio-automatedx86-sb.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-studio-automatedx86-sb.balenaos-img'
+		deployRawArtifact: 'balena-image-studio-automatedx86-sb.balenaos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	options: [ networkOptions.group ]
+
+	initialization: commonImg.initialization


### PR DESCRIPTION
This creates a new device type that uses kernel module signing.

Changelog-entry: Add new studio-automatedx86-sb device type for kernel module signing based on generic-amd64