### PR TITLE
Improve support for Cinterion ALAS5 modem

### DIFF
--- a/layers/meta-balena-generic/recipes-kernel/linux/files/0001-cinterion-mbim.patch
+++ b/layers/meta-balena-generic/recipes-kernel/linux/files/0001-cinterion-mbim.patch
@@ -1,0 +1,16 @@
+diff --git a/drivers/net/usb/cdc_mbim.c b/drivers/net/usb/cdc_mbim.c
+index cd4083e0b3b9..afd784712ea6 100644
+--- a/drivers/net/usb/cdc_mbim.c
++++ b/drivers/net/usb/cdc_mbim.c
+@@ -670,6 +670,11 @@ static const struct usb_device_id mbim_devs[] = {
+ 	  .driver_info = (unsigned long)&cdc_mbim_info_avoid_altsetting_toggle,
+ 	},
+ 
++	/* Kontron MBIM */
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x1e2d, 0x0065, USB_CLASS_COMM, USB_CDC_SUBCLASS_MBIM, USB_CDC_PROTO_NONE),
++	  .driver_info = (unsigned long)&cdc_mbim_info_avoid_altsetting_toggle,
++	},
++
+ 	/* default entry */
+ 	{ USB_INTERFACE_INFO(USB_CLASS_COMM, USB_CDC_SUBCLASS_MBIM, USB_CDC_PROTO_NONE),
+ 	  .driver_info = (unsigned long)&cdc_mbim_info_zlp,

--- a/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -12,6 +12,10 @@ SRC_URI:append:generic-aarch64 = " \
     file://0002-HACK-Use-the-UNAME26-personality-to-return-armv6l-in.patch;sha256sum=a3665233eebd44dc8f34ddda9ae9446bb1ef2f9c06979850bd9cc60d1e7d6f79 \
     "
 
+SRC_URI:append = " \
+    file://0001-cinterion-mbim.patch;sha256sum=ed6fb66934cf9f1117efab8887ef67f0fb73286301a84430550700e9d57fd102 \
+"
+
 KCONFIG_MODE="--alldefconfig"
 
 # enable AUFS support from kernel-balena


### PR DESCRIPTION
* Add cdc_mbim.c patch to correctly use ALAS5
* Add udev rules for ALAS5