### PR TITLE
balena-image.inc: remove IMAGE_FSTYPES override

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.inc
@@ -1,5 +1,4 @@
 DEPENDS:remove = "kernel-modules-headers"
-IMAGE_FSTYPES = " balenaos-img"
 
 PARTITION_TABLE_TYPE = "gpt"
 


### PR DESCRIPTION
At this moment meta-balena-raspberrypi overrides IMAGE_FSTYPES, which breaks the build of signed images, because we have introduced a separate image type for that use case. The override also seems unnecessary, as it sets the value to the exact same thing that meta-balena already did.

This patch removes the override and makes the devices use the definition from meta-balena, which does account for the signature split.