### PR TITLE
Remove AMD Ryzen label from generic-amd64 test matrix

### DIFF
--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -64,13 +64,11 @@ jobs:
       # Sign image for secure boot
       sign-image: true
       # Use QEMU workers for testing and run cloud suite against balenaCloud production.
-      # Avoid the AMD EPYC processors on the AX162 hosts as they seem to break SMP for secure boot.
-      # The AMD Ryzen 9 7950X3D 16-Core Processor is found in the AX102 hosts.
       test_matrix: >
         {
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm", "cpu_model:AMD_Ryzen_9_7950X3D_16-Core_Processor"]],
+          "runs_on": [["self-hosted", "X64", "kvm"]],
           "secure_boot": ["sb",""]
         }


### PR DESCRIPTION
The boot issue on EPYC processors was resolved
by bumping OMVF in the leviathan-worker container.

See: https://github.com/balena-os/leviathan-worker/pull/136
See: https://balena.fibery.io/Work/Project/Investigation-of-secure-boot-tests-not-booting-on-self-hosted-runners-1030

- [x] Depends-on: https://github.com/balena-os/leviathan/pull/1275
- [x] Depends-on: https://github.com/balena-os/meta-balena/pull/3611
- [x] Depends-on: https://github.com/balena-os/balena-generic/pull/560