### PR TITLE
Provide signing environments to yocto workflows

### DIFF
--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@c7f1eedcbda30d1e4031d1dff33176ce9be1e526
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@15df9f8eae3005733daf7110c8128fc8a4541d1b
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/generic-amd64-fs.yml
+++ b/.github/workflows/generic-amd64-fs.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@c7f1eedcbda30d1e4031d1dff33176ce9be1e526
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@15df9f8eae3005733daf7110c8128fc8a4541d1b
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/generic-amd64-fs.yml
+++ b/.github/workflows/generic-amd64-fs.yml
@@ -29,7 +29,7 @@ on:
         description: Environment to use for build and deploy
         required: false
         type: string
-        default: balena-staging.com+generic-amd64-fs-signing-key
+        default: balena-staging.com
       meta-balena-ref:
         description: meta-balena ref if not the currently pinned version
         required: false
@@ -58,10 +58,11 @@ jobs:
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
-      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com+generic-amd64-fs-signing-key' }}
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
       # Allow overriding the meta-balena ref for workflow dispatch events
       meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}
       # Sign image for secure boot
       sign-image: true
+      signing-environment: sign.balena-cloud.com+generic-amd64-fs
       # FIXME: Disable finalize-on-push until we have a test to verify that SIGN_KMOD_KEY_APPEND is set
       finalize-on-push-if-tests-passed: false

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -29,7 +29,7 @@ on:
         description: Environment to use for build and deploy
         required: false
         type: string
-        default: balena-staging.com+sign-api-key
+        default: balena-staging.com
       meta-balena-ref:
         description: meta-balena ref if not the currently pinned version
         required: false
@@ -58,11 +58,12 @@ jobs:
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
-      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com+sign-api-key' }}
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
       # Allow overriding the meta-balena ref for workflow dispatch events
       meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}
       # Sign image for secure boot
       sign-image: true
+      signing-environment: sign.balena-cloud.com
       # Publish AMI for this device type
       deploy-ami: true
       # Use QEMU workers for testing and run cloud suite against balenaCloud production.

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@c7f1eedcbda30d1e4031d1dff33176ce9be1e526
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@15df9f8eae3005733daf7110c8128fc8a4541d1b
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -71,6 +71,6 @@ jobs:
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]],
+          "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
           "secure_boot": ["sb",""]
         }

--- a/.github/workflows/kontron-come-xelx.yml
+++ b/.github/workflows/kontron-come-xelx.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@c7f1eedcbda30d1e4031d1dff33176ce9be1e526
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@15df9f8eae3005733daf7110c8128fc8a4541d1b
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while

--- a/.github/workflows/studio-automatedx86-sb.yml
+++ b/.github/workflows/studio-automatedx86-sb.yml
@@ -29,7 +29,7 @@ on:
         description: Environment to use for build and deploy
         required: false
         type: string
-        default: balena-staging.com+studio-automatedx86-sb-signing-key
+        default: balena-staging.com
       meta-balena-ref:
         description: meta-balena ref if not the currently pinned version
         required: false
@@ -58,9 +58,10 @@ jobs:
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
-      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com+studio-automatedx86-sb-signing-key' }}
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
       # Sign image for secure boot
       sign-image: true
+      signing-environment: sign.balena-cloud.com+studio-automatedx86-sb
       # FIXME: Disable finalize-on-push until we have a test to verify that SIGN_KMOD_KEY_APPEND is set
       finalize-on-push-if-tests-passed: false
       # Allow overriding the meta-balena ref for workflow dispatch events

--- a/.github/workflows/studio-automatedx86-sb.yml
+++ b/.github/workflows/studio-automatedx86-sb.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@c7f1eedcbda30d1e4031d1dff33176ce9be1e526
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@15df9f8eae3005733daf7110c8128fc8a4541d1b
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
     # This condition will prevent the workflow from running twice for the same pull request while


### PR DESCRIPTION
See: https://balena.fibery.io/Work/Project/Separate-balenaOS-signing-environments-from-deploy-environments-1049

- [x] Depends-on: https://github.com/balena-os/balena-yocto-scripts/pull/519
- [x] Depends-on: https://github.com/balena-os/.github/pull/371