### PR TITLE
Add workflow_call trigger to each device workflow

### DIFF
--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -35,6 +35,29 @@ on:
         required: false
         type: string
         default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
@@ -55,6 +78,9 @@ jobs:
     secrets: inherit
     with:
       machine: generic-aarch64
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || '' }}
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events

--- a/.github/workflows/generic-amd64-fs.yml
+++ b/.github/workflows/generic-amd64-fs.yml
@@ -35,6 +35,29 @@ on:
         required: false
         type: string
         default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
@@ -55,6 +78,9 @@ jobs:
     secrets: inherit
     with:
       machine: generic-amd64-fs
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || '' }}
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -35,6 +35,29 @@ on:
         required: false
         type: string
         default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
@@ -55,6 +78,9 @@ jobs:
     secrets: inherit
     with:
       machine: generic-amd64
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || '' }}
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events

--- a/.github/workflows/kontron-come-xelx.yml
+++ b/.github/workflows/kontron-come-xelx.yml
@@ -35,6 +35,29 @@ on:
         required: false
         type: string
         default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
@@ -55,6 +78,9 @@ jobs:
     secrets: inherit
     with:
       machine: kontron-come-xelx
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || '' }}
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events

--- a/.github/workflows/studio-automatedx86-sb.yml
+++ b/.github/workflows/studio-automatedx86-sb.yml
@@ -35,6 +35,29 @@ on:
         required: false
         type: string
         default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
@@ -55,6 +78,9 @@ jobs:
     secrets: inherit
     with:
       machine: studio-automatedx86-sb
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || '' }}
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}
       # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events


### PR DESCRIPTION
This simplifies the workflow required for meta-balena testing as it can just call the device workflows directly.

Changelog-entry: Add workflow_call trigger for testing

See: https://balena.fibery.io/Work/Project/Add-workflow_call-trigger-to-device-repo-workflows-for-meta-balena-1057
See: https://balena.fibery.io/Work/Project/Add-secureboot-tests-to-meta-balena-1261