### PR TITLE
Allow secure boot tests to run on AX162 runners

### DIFF
--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -93,11 +93,14 @@ jobs:
       # Publish AMI for this device type
       deploy-ami: true
       # Use QEMU workers for testing and run cloud suite against balenaCloud production.
+      # Use AX102 runners as the AX162 runners have issues with QEMU and AMD EPYC processors.
+      # See https://balena.fibery.io/Work/Project/Investigation-of-secure-boot-tests-not-booting-on-self-hosted-runners-1030
+      # See https://unix.stackexchange.com/questions/757583/linux-reboots-with-no-panic-when-booting-smp-configuration-from-kexec
       test_matrix: >
         {
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
+          "runs_on": [["self-hosted", "X64", "kvm", "yocto"]],
           "secure_boot": ["sb",""]
         }


### PR DESCRIPTION
Changelog-entry: Unpin the secure boot tests from the AX102 runners