### PR TITLE
Require a new "qemu-os" tag for leviathan QEMU suites

### DIFF
--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -66,9 +66,29 @@ permissions:
   packages: read
   contents: read
 
+env:
+  # Use QEMU workers for testing and run cloud suite against balenaCloud production
+  test_matrix: >
+    {
+      "test_suite": ["os","cloud","hup"],
+      "environment": ["balena-cloud.com"],
+      "worker_type": ["qemu"],
+      "runs_on": [["self-hosted", "X64", "kvm"]]
+    }
+
 jobs:
+  # Custom job to use multi-line env vars as defaults for empty inputs
+  get_inputs:
+    name: Get inputs
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
+    steps:
+      - run: echo "Hello World!"    
+
   yocto:
     name: Yocto
+    needs: get_inputs
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@d2b30dabd4df9ded5a2d0f4250a09e2516eda209
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -87,11 +107,4 @@ jobs:
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
       # Allow overriding the meta-balena ref for workflow dispatch events
       meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}
-      # Use QEMU workers for testing and run cloud suite against balenaCloud production
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["balena-cloud.com"],
-          "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm"]]
-        }
+      test_matrix: ${{ needs.get_inputs.outputs.test_matrix }}

--- a/.github/workflows/generic-aarch64.yml
+++ b/.github/workflows/generic-aarch64.yml
@@ -73,7 +73,7 @@ env:
       "test_suite": ["os","cloud","hup"],
       "environment": ["balena-cloud.com"],
       "worker_type": ["qemu"],
-      "runs_on": [["self-hosted", "X64", "kvm"]]
+      "runs_on": [["self-hosted", "X64", "kvm", "qemu-os"]]
     }
 
 jobs:

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -66,9 +66,30 @@ permissions:
   packages: read
   contents: read
 
+env:
+  # Use QEMU workers for testing and run cloud suite against balenaCloud production.
+  test_matrix: >
+    {
+      "test_suite": ["os","cloud","hup"],
+      "environment": ["balena-cloud.com"],
+      "worker_type": ["qemu"],
+      "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
+      "secure_boot": ["sb",""]
+    }
+
 jobs:
+  # Custom job to use multi-line env vars as defaults for empty inputs
+  get_inputs:
+    name: Get inputs
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
+    steps:
+      - run: echo "Hello World!"    
+          
   yocto:
     name: Yocto
+    needs: get_inputs
     uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@d2b30dabd4df9ded5a2d0f4250a09e2516eda209
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
@@ -92,12 +113,4 @@ jobs:
       signing-environment: sign.balena-cloud.com
       # Publish AMI for this device type
       deploy-ami: true
-      # Use QEMU workers for testing and run cloud suite against balenaCloud production.
-      test_matrix: >
-        {
-          "test_suite": ["os","cloud","hup"],
-          "environment": ["balena-cloud.com"],
-          "worker_type": ["qemu"],
-          "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
-          "secure_boot": ["sb",""]
-        }
+      test_matrix: ${{ needs.get_inputs.outputs.test_matrix }}

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -73,7 +73,7 @@ env:
       "test_suite": ["os","cloud","hup"],
       "environment": ["balena-cloud.com"],
       "worker_type": ["qemu"],
-      "runs_on": [["self-hosted", "X64", "kvm"]],
+      "runs_on": [["self-hosted", "X64", "kvm", "qemu-os"]],
       "secure_boot": ["sb",""]
     }
 

--- a/.github/workflows/generic-amd64.yml
+++ b/.github/workflows/generic-amd64.yml
@@ -73,7 +73,7 @@ env:
       "test_suite": ["os","cloud","hup"],
       "environment": ["balena-cloud.com"],
       "worker_type": ["qemu"],
-      "runs_on": [["self-hosted", "X64", "kvm", "AX102"]],
+      "runs_on": [["self-hosted", "X64", "kvm"]],
       "secure_boot": ["sb",""]
     }
 


### PR DESCRIPTION
**Fix support for test_matrix on workflow_call**
Previously when meta-balena would provide a value for
test_matrix it was not being used.

This change allows the calling workflow to provide a custom
test matrix while still providing the multi-line default
matrix for other event types.

**Remove the AX102 requirement for secure boot tests**
The latest self-hosted runners support cpu templates
so the guests will experience a consistent feature set
supported by the host.

**Require a new "qemu-os" tag for leviathan QEMU suites**
This allows us some control over which runners are available
for long-running leviathan QEMU test suites that download large
image files.

See: https://balena.fibery.io/Work/Improvement/Require-a-new-qemu-os-tag-for-leviathan-QEMU-suites-3184
See: https://balena.fibery.io/Work/Improvement/GitHub-VMs-Allow-loading-custom-guest-cpu-templates-3180
See: https://balena.fibery.io/Inputs/Pattern/QEMU-secure-boot-tests-do-not-boot-on-AMD-EPYC-chipset-self-hosted-runners-5130
See: https://balena.fibery.io/Inputs/Pattern/balenaOS-github-actions-frequent-failures-timeouts-during-download-artifact-step-5155

