### PR TITLE
linux-yocto_%.bbappend: Enable Mellanox ConnectX mlx5 core VPI Networ…

### DIFF
--- a/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -382,3 +382,12 @@ BALENA_CONFIGS:append:generic-amd64 = " pinctrl_alderlake"
 BALENA_CONFIGS[pinctrl_alderlake] = " \
     CONFIG_PINCTRL_ALDERLAKE=m \
 "
+
+# needed for Leaseweb dedicated instances
+# https://docs.kernel.org/next/networking/device_drivers/ethernet/mellanox/mlx5.html
+BALENA_CONFIGS:append:generic-amd64 = " mlx5"
+BALENA_CONFIGS:append:generic-aarch64 = " mlx5"
+BALENA_CONFIGS[mlx5] = "\
+    CONFIG_MLX5_CORE=m \
+    CONFIG_MLX5_CORE_EN=y \
+"


### PR DESCRIPTION
…k Driver

Mellanox ConnectX network cards are used in Leaseweb dedicated servers that we hope to use for some hosting.

Changelog-entry: Enable Mellanox ConnectX mlx5 core VPI Network Driver

See: https://balena.fibery.io/Work/Improvement/Enable-Mellanox-ConnectX-mlx5-core-VPI-Network-Driver-3247
See: https://docs.kernel.org/next/networking/device_drivers/ethernet/mellanox/mlx5.html