### PR TITLE
Feature: generic: Disable lid-switch handling in systemd-logind

### DIFF
--- a/layers/meta-balena-generic/recipes-core/systemd/systemd/10-balena-lid.conf
+++ b/layers/meta-balena-generic/recipes-core/systemd/systemd/10-balena-lid.conf
@@ -1,0 +1,3 @@
+[Login]
+HandleLidSwitch=ignore
+HandleLidSwitchDocked=ignore

--- a/layers/meta-balena-generic/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-balena-generic/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,23 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:generic-amd64 = " \
+    file://10-balena-lid.conf \
+    "
+SRC_URI:append:generic-aarch64 = " \
+    file://10-balena-lid.conf \
+    "
+
+do_install:append:generic-amd64() {
+    install -d ${D}${sysconfdir}/systemd/logind.conf.d
+    install -m 0644 ${WORKDIR}/10-balena-lid.conf \
+        ${D}${sysconfdir}/systemd/logind.conf.d/10-balena-lid.conf
+}
+
+do_install:append:generic-aarch64() {
+    install -d ${D}${sysconfdir}/systemd/logind.conf.d
+    install -m 0644 ${WORKDIR}/10-balena-lid.conf \
+        ${D}${sysconfdir}/systemd/logind.conf.d/10-balena-lid.conf
+}
+
+FILES:${PN}:append:generic-amd64 = " ${sysconfdir}/systemd/logind.conf.d/10-balena-lid.conf"
+FILES:${PN}:append:generic-aarch64 = " ${sysconfdir}/systemd/logind.conf.d/10-balena-lid.conf"


### PR DESCRIPTION
Feature:

Drops a logind drop-in that sets HandleLidSwitch=ignore and HandleLidSwitchDocked=ignore so closing the lid on laptop-class hardware does not suspend the device.

Applies to generic-amd64 and generic-aarch64.

Change-type: patch