### PR TITLE
hostapp-update-hooks: Fix efibootmgr parsing in resin-boot-cleaner

### DIFF
--- a/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
+++ b/layers/meta-balena-generic/recipes-support/hostapp-update-hooks/files/999-resin-boot-cleaner
@@ -30,20 +30,20 @@ if [ "$DURING_UPDATE" = "1" ]; then
 		boot_dev=$(findmnt --noheadings --canonicalize --output SOURCE "$BALENA_BOOT_MOUNTPOINT")
 		type=$(lsblk -no TYPE "${boot_dev}")
 		if [ "${type}" != "crypt" ]; then
-			# re-add the EFI entry for resinOS boot from internal media as some EFI firmwares are buggy and won't detect the old entry anymore
-			# first remove existing resinOS entries so we won't have duplicates
+			# re-add the EFI entry for balenaOS boot from internal media as some EFI firmwares are buggy and won't detect the old entry anymore
+			# first remove existing balenaOS entries so we won't have duplicates
 			# Do not do this on systems with LUKS-encrypted drives though, the boot order in this case is protected by PCR checksums.
 			# Touching it in any way would make the system unbootable.
 			boot_part="/dev/$(lsblk -sJ "${boot_dev}" | jq -r '.blockdevices[].name')"
 			device="/dev/$(lsblk "$boot_part" -dnlo PKNAME)"
-			printf "[INFO] Re-add EFI boot entry for starting resinOS from internal media.\n"
+			printf "[INFO] Re-add EFI boot entry for starting balenaOS from internal media.\n"
 			if [ -z "$(ls -A /sys/firmware/efi/efivars)" ]; then
 				# efivars not bind-mounted by hostapp-update script
 				mount -t efivarfs efivarfs /sys/firmware/efi/efivars
 			fi
-			duplicates=`efibootmgr | grep resinOS |sed 's/Boot*//g' | sed 's/* resinOS//g'`
+			duplicates=`efibootmgr | grep "resinOS\|balenaOS" | sed -e "s,^Boot\([0-9]*\)\*.*$,\1,"`
 			for i in $duplicates; do efibootmgr -B -b $i; done
-			efibootmgr -c -d $device -p 1 -L "resinOS" -l "\EFI\BOOT\bootx64.efi"
+			efibootmgr -c -d $device -p 1 -L "balenaOS" -l "\EFI\BOOT\bootx64.efi"
 		fi
 	fi
 fi


### PR DESCRIPTION
At this moment the resin-boot-cleaner hook parses the output of `efibootmgr` to remove duplicate resinOS boot entries. It expects a very specific format:
```
Boot0002* resinOS
Boot0004* balenaOS
```

But on aarch64, the output also includes the executable path:
```
Boot0003* resinOS       HD(...)/\EFI\BOOT\bootx64.efi
```

Because of that the parsing fails, kills the hook and fails the HUP or rollback being executed.

This patch does two things:
* Updates the parser to work with both output variants
* Replaces resinOS with balenaOS