### PR TITLE
add generic-amd-64-av device type

### DIFF
--- a/.github/workflows/generic-amd64-av.yml
+++ b/.github/workflows/generic-amd64-av.yml
@@ -1,0 +1,93 @@
+name: Generic x86_64 (GPT) av
+
+on:
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+  pull_request:
+    branches:
+      - main
+      - master
+      # ESR branches glob pattern
+      # - 20[0-9][0-9].[0-1]?[1470].x
+  pull_request_target:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      # Semver tags glob pattern (includes ESR in format v20YY.MM.PATCH)
+      - v[0-9]+.[0-9]+.[0-9]+\+?r?e?v?*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      force-finalize:
+        description: Force finalize of the build (implicitly enables hostapp and S3 deployments)
+        required: false
+        type: boolean
+        default: false
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+  # Allow this workflow to be called by other workflows
+  workflow_call:
+    inputs:
+      deploy-environment:
+        description: Environment to use for build and deploy
+        required: false
+        type: string
+        default: balena-staging.com
+      meta-balena-ref:
+        description: meta-balena ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      device-repo-ref:
+        description: device-repo ref if not the currently pinned version
+        required: false
+        type: string
+        default: ''
+      test_matrix:
+        description: "JSON Leviathan test matrix to use for testing. No tests will be run if not provided."
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  id-token: write # This is required for requesting the JWT #https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#requesting-the-access-token
+  actions: read # We are fetching workflow run results of a merge commit when workflow is triggered by new tag, to see if tests pass
+  pull-requests: write # Read is required to fetch the PR that merged, in order to get the test results. Write is required to create PR comments for workflow approvals.
+  packages: read
+  contents: read
+
+jobs:
+  yocto:
+    name: Yocto
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@7d1760c79d5584f3d6bf9a1c2d0e796b6a5b5d82
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
+    secrets: inherit
+    with:
+      machine: generic-amd64-av
+      # Hardcode the device repo in case this workflow is called by another workflow
+      device-repo: balena-os/balena-generic
+      device-repo-ref: ${{ inputs.device-repo-ref || github.ref }}
+      # Allow manual workflow runs to force finalize without checking previous test runs
+      force-finalize: ${{ inputs.force-finalize || false }}
+      # Default to balena-staging.com for workflow dispatch, but balena-cloud.com for other events
+      deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
+      # Allow overriding the meta-balena ref for workflow dispatch events
+      meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}
+      # Sign image for secure boot
+      sign-image: true
+      extra_signing_key: true # expect a separate signing key for the kernel module signing
+      signing-environment: sign.balena-cloud.com+generic-amd64-av

--- a/generic-amd64-av.coffee
+++ b/generic-amd64-av.coffee
@@ -1,0 +1,61 @@
+deviceTypesCommon = require '@resin.io/device-types/common'
+{ networkOptions, commonImg, instructions } = deviceTypesCommon
+
+DISABLE_SECURE_BOOT = 'Make sure Secure Boot is disabled in BIOS.'
+GENERIC_FLASH = '''
+	Please make sure you do not have any other USB keys inserted.
+	Power up the hardware. Make sure you have a keyboard connected.
+	Press the F10 key (may differ on some platforms) while BIOS is loading in order to enter the boot menu.
+	Next, select the name of your USB key.
+'''
+
+GENERIC_POWERON = 'Power on your device.'
+
+postProvisioningInstructions = [
+	instructions.BOARD_SHUTDOWN
+	instructions.REMOVE_INSTALL_MEDIA
+	GENERIC_POWERON
+]
+
+module.exports =
+	version: 1
+	slug: 'generic-amd64-av'
+	name: 'Generic x86_64 (GPT) av'
+	arch: 'amd64'
+	state: 'new'
+
+	stateInstructions:
+		postProvisioning: postProvisioningInstructions
+
+	instructions: [
+		instructions.ETCHER_USB
+		instructions.EJECT_USB
+		instructions.FLASHER_WARNING
+		DISABLE_SECURE_BOOT
+		GENERIC_FLASH
+	].concat(postProvisioningInstructions)
+
+	gettingStartedLink:
+		windows: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		osx: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+		linux: 'https://www.balena.io/docs/learn/getting-started/intel-nuc/nodejs/'
+
+	yocto:
+		machine: 'generic-amd64-av'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
+		version: 'yocto-scarthgap'
+		deployArtifact: 'balena-image-flasher-generic-amd64-av.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-generic-amd64-av.balenaos-img'
+		deployRawArtifact: 'balena-image-generic-amd64-av.balenaos-img'
+		compressed: true
+
+	configuration:
+		config:
+			partition:
+				primary: 1
+			path: '/config.json'
+
+	options: [ networkOptions.group ]
+
+	initialization: commonImg.initialization

--- a/layers/meta-balena-generic/conf/machine/generic-amd64-av.conf
+++ b/layers/meta-balena-generic/conf/machine/generic-amd64-av.conf
@@ -1,0 +1,8 @@
+#@TYPE: Machine
+#@NAME: Generic amd64 av
+#@DESCRIPTION: Machine configuration for Generic amd64 av
+
+include conf/machine/generic-amd64.conf
+MACHINEOVERRIDES = "generic-amd64:${MACHINE}"
+
+OS_KERNEL_CMDLINE:append = " modprobe.blacklist=nouveau,nvidiafb"

--- a/layers/meta-balena-generic/conf/templates/default/local.conf.sample
+++ b/layers/meta-balena-generic/conf/templates/default/local.conf.sample
@@ -2,6 +2,7 @@
 #MACHINE ?= "generic-aarch64.conf"
 #MACHINE ?= "generic-amd64.conf"
 #MACHINE ?= "generic-amd64-fs.conf"
+#MACHINE ?= "generic-amd64-av.conf"
 #MACHINE ?= "studio-automatedx86-sb"
 
 # More info meta-balena/README.md


### PR DESCRIPTION
Changelog-entry: add generic-amd-64-av device type

requires https://github.com/balena-os/.github/pull/1609 to merge to make the secrets available
then requires another PR in the above repo to make the checks required. 