### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-generic/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-generic/recipes-core/images/balena-image.inc
@@ -31,3 +31,12 @@ IMAGE_INSTALL:append = " \
     linux-firmware \
     efibootmgr \
     "
+
+BALENA_BOOT_SIZE:generic-aarch64 = "40960"
+BALENA_STATE_SIZE:generic-aarch64 = "20480"
+BALENA_BOOT_SIZE:generic-amd64-av = "40960"
+BALENA_STATE_SIZE:generic-amd64-av = "20480"
+BALENA_BOOT_SIZE:generic-amd64-fs = "40960"
+BALENA_STATE_SIZE:generic-amd64-fs = "20480"
+BALENA_BOOT_SIZE:generic-amd64 = "40960"
+BALENA_STATE_SIZE:generic-amd64 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.