### PR TITLE
linux-yocto: Enable gpio-usbio driver

### DIFF
--- a/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/layers/meta-balena-generic/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -438,3 +438,11 @@ BALENA_CONFIGS[storage] = " \
     CONFIG_SCSI_GDTH=y \
     CONFIG_SCSI_IPS=y \
 "
+
+BALENA_CONFIGS:append = " gpio_usbio"
+BALENA_CONFIGS_DEPS[gpio_usbio] = " \
+    CONFIG_USB_USBIO=m \
+"
+BALENA_CONFIGS[gpio_usbio] = " \
+    CONFIG_GPIO_USBIO=m \
+"


### PR DESCRIPTION
As per custome request in https://balena.zendesk.com/agent/tickets/6512

Changelog-entry: Enable gpio-usbio driver as per customer request